### PR TITLE
Add on_departure event to travellers

### DIFF
--- a/docs/behaviour.md
+++ b/docs/behaviour.md
@@ -19,12 +19,13 @@ the graph with the `add_function` function.
 
 The functions which control the behaviour of the graph are triggered by the following events:
 
-| event type  | on        | description          
-|-------------+-----------|-----------------------------
-| `on_init`   | graph     | runs when the graph is initialised 
-| `on_tick`   | graph     | runs every 'tick', if `tick_period` is not zero 
-| `on_arrival`| traveller | run by a traveller when it arrives at the end of its journey along an edge
-| `on_click`  | vertex, edge, traveller | runs when user clicks on component
+| event type     | on        | description          
+|----------------+-----------|-----------------------------
+| `on_init`      | graph     | runs when the graph is initialised 
+| `on_tick`      | graph     | runs every 'tick', if `tick_period` is not zero 
+| `on_departure` | traveller | run by a traveller just before it sets off on a journey along an edge
+| `on_arrival` | traveller | run by a traveller when it arrives at the end of its journey along an edge
+| `on_click`     | vertex, edge, traveller | runs when user clicks on component
 | `on_mouseover` | vertex, edge, traveller | runs when user's mouse pointer moves over component
 
 The function is called with two arguments: `event` and `graph`. You can also
@@ -136,15 +137,18 @@ Useful fields:
 | `.following_edge`    | the edge (`GraphEdge` object) that this traveller is following (`null` if it is not travelling)
 | `.at_vertex`         | the vertex at which this traveller is currently resting (or at which it has just arrvied — see note below)
 
-The `from`, `to`, and `following_edge` fields are cleared _after_ the
-traveller's `on_arrival` event is fired. The `at_vertex` field is populated
+The `from`, `to`, and `following_edge` fields are set _before_ the traveller's
+`on_departure` event, and cleared _after_ its `on_arrival` event. Additionally,
+the `at_vertex` field is cleared after the `on_departure` event and populated
 just before the `on_arrival` event — so all those fields are useful to you when
-programming `on_arrival` functions.
+programming the traveller's journey-based event functions.
 
 The `Traveller` object has a `travel(edge)` function, which you can use to set
-a traveller on its journey. Make sure the traveller's `at_vertex` is indeed one
-`from` end of the `edge` you provide as an argument (or either of the ends if
-the edge is bi-directional). 
+a traveller on its journey. Make sure the traveller _can_ travel along that
+edge based on its current location. That is, its `at_vertex` must be the same
+vertex as `edge.from` (or either of `edge.from` or `edge.to` if the edge is
+bi-directional) — otherwise this call will do nothing. Calling `travel` will
+subequently trigger the `on_departure` event if this traveller has one defined.
 
 To programmatically create a traveller, use its constructor (which takes a config which _must_ include an `at_vertex`, and the graph to which it belongs).
 Currently you need to explictly add the `diagram` to the stage, and push it onto

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -24,7 +24,7 @@ created and destroyed.
 
 | **vertices**   | Vertices are the nodes of the directed graph. Vertices must have a unique ID. All vertices are rendered as circles. Vertices can be rendered with an additional ring, and can be made to pulse (showing an animated surround).
 | **edges**      | Edges are rendered as lines joining the vertices of the graph, and are directed (that is, they have a `from` and a `to` vertex). Edges can be bi-directional, and can be drawn with or without arrowheads. An edge can loop, joining a vertex to itself.
-| **travellers** | Travellers move along the edges, vertex-to-vertex, and can be either circles ("spots") or graphics (sprites). Travellers can have an `on_arrival` event handler, which can be useful for programming [graph behaviour](behaviour).
+| **travellers** | Travellers move along the edges, vertex-to-vertex, and can be either circles ("spots") or graphics (sprites). Travellers can have `on_departure` and `on_arrival` event handlers, which can be useful for programming [graph behaviour](behaviour).
 
 
 
@@ -184,8 +184,9 @@ The `journey_lifespan` of a traveller — either defined explicitly here, or in 
 | _n_                | _specific n_: traveller makes _n_ journeys
 
 
-The `on_arrival` event is unique to travellers, and you can programmatically
-create and destroy travellers: see [behaviour](behaviour) for more information.
+The `on_departure` and `on_arrival` events are unique to travellers, and you
+can programmatically create and destroy travellers: see [behaviour](behaviour)
+for more information.
 
 
 ### Config for all vertices
@@ -296,7 +297,8 @@ values.
 | `resource_id`          | `pixi-bunny`  | the name of the resource to use as the bitmap for a sprite-type traveller
 | `sprite_scale`         | `1`           | the scale of the sprite-type traveller
 | `is_displaying_payload`| `false`       | `true` if the value of the traveller's payload should be displayed
-| `on_arrival`           | `null`        | what function should be run when the traveller arrives at the end of its journey.
+| `on_departure`           | `null`        | what function should be run when the traveller departs on its journey
+| `on_arrival`           | `null`        | what function should be run when the traveller arrives at the end of its journey
 | `on_click`             | `null`        | what function should be run if the edge is clicked. Set this to null if you don't want any interaction.
 | `on_moueseover`        | `null`        | what function should be run if the mouse pointer moves over the traveller. Set this to null if you don't want any interaction.
 | `payload`              | `0`           | initial value of the payload       

--- a/graphfellow.js
+++ b/graphfellow.js
@@ -99,6 +99,7 @@
       "is_text_wordwrap": false,
       "text_wordwrap_width": 10,
       "on_arrival":       null,
+      "on_departure":     null,
       "on_click":         null,
       "on_mouseover":     null
     },
@@ -793,6 +794,9 @@
       this.following_edge = edge;
       this.from = this.at_vertex;
       this.to = edge.to === this.from? edge.from : edge.to; // reverse
+      if (functions[this.on_departure] instanceof Function) {
+        functions[this.on_departure].call(this, new Event("departure"), this.graph);
+      }
       this.at_vertex = null;
       let settings_json = edge.get_tween_data(this.from);
       let traveller = this;


### PR DESCRIPTION
Looks like adding `on_departure` was reasonably straightforward: basically the same as `on_arrival` but triggered by the `travel()` method which is always called to commence the journey.